### PR TITLE
Add  to storage adapter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Open your `config.[env].json` in the Ghost root directory and add a `storage` se
   "gcs": {
     "bucket": "your-gcs-bucket-name",
     "keyFilename": "path-to-your-service-account.json",
+    "pathPrefix": "content/images",
     "cdn": "optional-cdn-domain"
   }
 }
@@ -49,3 +50,5 @@ Open your `config.[env].json` in the Ghost root directory and add a `storage` se
 **keyFilename**: Optional if Ghost is hosted on GCP.
 
 **cdn**: Optional. If you use a CDN, this is the CDN base URL.
+
+**pathPrefix**: Optional. Uploads default to root of the bucket.

--- a/src/index.js
+++ b/src/index.js
@@ -8,21 +8,14 @@ class GoogleCloudStorageAdapter extends BaseAdapter {
   constructor(config = {}) {
     super(config);
 
-    let storage;
-    
-    if (config.keyFilename) {
-      storage = new Storage({
-        keyFilename: config.keyFilename
-      });
-    } else {
-      storage = new Storage();
-    }
+    const storage = config.keyFilename ? new Storage({ keyFilename: config.keyFilename }) : new Storage();
     
     this.bucket = storage.bucket(config.bucket);
     this.assetDomain = `${config.bucket}.storage.googleapis.com`;
     if (config.cdn) {
       this.assetDomain = config.cdn;
     }
+    this.pathPrefix = config.pathPrefix;
   }
 
   exists(fileName, targetDir) {
@@ -35,7 +28,7 @@ class GoogleCloudStorageAdapter extends BaseAdapter {
   }
 
   save(image) {
-    const targetDir = this.getTargetDir();
+    const targetDir = this.getTargetDir(this.pathPrefix);
     let targetFilename;
     return this.getUniqueFileName(image, targetDir)
       .then(fileName => {
@@ -68,8 +61,8 @@ class GoogleCloudStorageAdapter extends BaseAdapter {
   }
 
   read(options = {}) {
-    const prefix = `https://${this.assetDomain}/`
-    let path = options.path
+    const prefix = `https://${this.assetDomain}/`;
+    let path = options.path;
     if (path.indexOf(prefix) === 0) {
       path = path.slice(prefix.length);
     }


### PR DESCRIPTION
We add `pathPrefix` as an option to define which folder will the uploads be placed in the Google Cloud Storage bucket.